### PR TITLE
GA4 Tracking Js

### DIFF
--- a/docs/deploy/index.html
+++ b/docs/deploy/index.html
@@ -1,6 +1,16 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-MS7P05T8S2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-MS7P05T8S2');
+    </script>
+    
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="">


### PR DESCRIPTION
Added the Google analytics tracking JS for GA 4 (The latest version of Google Analytics.)

# Pull request questions
Q: Can you please double-check that I understand the behavior of this snippet correctly? I understand that with the new GA4 tracking code, they capture default events which include clicks off-page.  This implies that we should see sessions end on the page when a user clicks any one of the deployment options including contact us which will refer them to our support ticket form.

Sauce: https://support.google.com/analytics/answer/9234069?hl=en&ref_topic=9756175

## Which issue does this address

This picks up looking at user behavior onsight and if actions are taken from this page. It will show us the referral URLs in GA which should show traffic coming from Senzing.com and potentially other sources depending on how our evaluation page is indexed by search engines, and if we choose to use it as a primary landing page for specific campaigns. (Default reporting behavior for GA4.)

Issue number: #nnn

APP-422

## Why was change needed

Reporting

## What does change improve

Our ability to see what the heck people do on th page.
