### PR TITLE
Added Google Tag Manager for the Evaluate page GA4 Property

### DIFF
--- a/docs/deploy/index.html
+++ b/docs/deploy/index.html
@@ -10,7 +10,15 @@
 
       gtag('config', 'G-MS7P05T8S2');
     </script>
-    
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-5WJGZ3L');</script>
+    <!-- End Google Tag Manager -->
+
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="">


### PR DESCRIPTION

# Pull request questions
NA

## Which issue does this address

Added Google Tag Manager to enable granular reporting on clicks that take the user off the page, so that we can see if a deployment method was selected or if they went to some other url.

Issue number: #nnn
No issue number

## Why was change needed

See issue.  We needed to be able to see the specific off-page clicks so that we can set up goals/ conversions on the evaluate page.

## What does change improve

User behavior visibility in web site analytics reporting

